### PR TITLE
Enhance sandbox config and documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Sandbox CLI Tool
+
+The **sandbox** script creates an isolated chroot based environment with optional network access.  It copies a minimal set of binaries and configuration files so you can experiment without affecting the host system.
+
+## Features
+
+- Chroot based sandbox with optional network isolation
+- Mount a host directory inside the sandbox at `/mnt`
+- Automatically install Python packages from a configuration file
+- Copies git configuration and SSH keys so tools like `git` work inside the sandbox
+- Configurable via an INI style configuration file
+
+## Installation
+
+Clone this repository and make the `sandbox` script executable:
+
+```bash
+chmod +x sandbox
+```
+
+## Usage
+
+```bash
+./sandbox [OPTIONS]
+```
+
+Options:
+
+- `--config FILE` – Path to a configuration file. If omitted, defaults are used.
+- `--mnt DIRECTORY` – Host directory to mount at `/mnt` inside the sandbox.
+- `--create-sample-config` – Write an example configuration file `sb.conf.example` and exit.
+
+## Configuration File
+
+The configuration uses INI sections.  See `sb.conf.example` for a complete example.  Relevant sections include:
+
+- `[network]` – Control allowed ports and IP ranges.
+- `[packages]` – Python packages to install on startup.
+- `[applications]` – Additional system applications to copy into the sandbox.
+- `[ssh]` – Comma separated list of SSH key file names to copy into the sandbox.  When omitted, all keys found in `~/.ssh` or the mounted directory are copied.
+- `[environment]` – Extra environment variables.
+- `[profile]` – Custom shell commands to run when the sandbox starts.
+
+## License
+
+This project is licensed under the MIT License.  See [LICENSE](LICENSE) for details.

--- a/sandbox
+++ b/sandbox
@@ -79,7 +79,8 @@ class SandboxManager:
             'env_vars': {},
             'network_enabled': True,
             'internet_access': True,
-            'profile_script': None
+            'profile_script': None,
+            'ssh_keys': []  # SSH keys to copy into the sandbox (empty => all)
         }
         
         # If no config file provided, use defaults
@@ -132,6 +133,12 @@ class SandboxManager:
         if 'profile' in config:
             if 'script' in config['profile']:
                 self.config['profile_script'] = config['profile']['script']
+
+        if 'ssh' in config:
+            if 'keys' in config['ssh']:
+                self.config['ssh_keys'] = [
+                    key.strip() for key in config['ssh']['keys'].split(',') if key.strip()
+                ]
 
     def create_sandbox_root(self):
         """Create the sandbox root directory structure"""
@@ -364,15 +371,21 @@ alias l='ls -CF'
             f.write('fi\n')
             
             f.write('# Copy SSH keys for git authentication\n')
-            f.write('if [ -d /mnt/.ssh ]; then\n')
-            f.write('    cp -r /mnt/.ssh/* ~/.ssh/ 2>/dev/null || true\n')
-            f.write('    chmod 600 ~/.ssh/id_* 2>/dev/null || true\n')
-            f.write('    chmod 644 ~/.ssh/*.pub 2>/dev/null || true\n')
-            f.write('elif [ -d "$HOME/.ssh" ]; then\n')
-            f.write('    cp -r "$HOME/.ssh"/* ~/.ssh/ 2>/dev/null || true\n')
-            f.write('    chmod 600 ~/.ssh/id_* 2>/dev/null || true\n')
-            f.write('    chmod 644 ~/.ssh/*.pub 2>/dev/null || true\n')
-            f.write('fi\n')
+            f.write('mkdir -p ~/.ssh\n')
+            if self.config['ssh_keys']:
+                for key in self.config['ssh_keys']:
+                    f.write(f'if [ -f /mnt/.ssh/{key} ]; then cp /mnt/.ssh/{key} ~/.ssh/{key} 2>/dev/null || true; fi\n')
+                    f.write(f'if [ -f /mnt/.ssh/{key}.pub ]; then cp /mnt/.ssh/{key}.pub ~/.ssh/{key}.pub 2>/dev/null || true; fi\n')
+                    f.write(f'if [ -f "$HOME/.ssh/{key}" ]; then cp "$HOME/.ssh/{key}" ~/.ssh/{key} 2>/dev/null || true; fi\n')
+                    f.write(f'if [ -f "$HOME/.ssh/{key}.pub" ]; then cp "$HOME/.ssh/{key}.pub" ~/.ssh/{key}.pub 2>/dev/null || true; fi\n')
+            else:
+                f.write('if [ -d /mnt/.ssh ]; then\n')
+                f.write('    cp -r /mnt/.ssh/* ~/.ssh/ 2>/dev/null || true\n')
+                f.write('elif [ -d "$HOME/.ssh" ]; then\n')
+                f.write('    cp -r "$HOME/.ssh"/* ~/.ssh/ 2>/dev/null || true\n')
+                f.write('fi\n')
+            f.write('chmod 600 ~/.ssh/id_* 2>/dev/null || true\n')
+            f.write('chmod 644 ~/.ssh/*.pub 2>/dev/null || true\n')
             f.write('\n')
             
             # Install Python packages if specified
@@ -460,6 +473,11 @@ install = requests,numpy,pandas
 # Additional applications to include in sandbox (comma-separated)
 # Must be available on the host system
 include = htop,tree,jq,nano
+
+[ssh]
+# SSH keys to copy into the sandbox (comma-separated)
+# Omit or leave empty to copy all keys found in ~/.ssh or the mounted directory
+keys = id_rsa,id_ed25519
 
 [environment]
 # Environment variables to set in the sandbox

--- a/sb.conf.example
+++ b/sb.conf.example
@@ -1,0 +1,46 @@
+# Sandbox Configuration File
+# All sections are optional - defaults will be used if not specified
+
+[network]
+# Allowed outbound ports (comma-separated)
+# Default: 80,443,22,21,990,9418 (HTTP, HTTPS, SSH, FTP, FTPS, Git)
+allowed_ports = 80,443,22,21,990,9418
+
+# Allowed IP addresses/ranges (comma-separated) 
+# Default: 0.0.0.0/0 (all addresses)
+allowed_ips = 0.0.0.0/0
+
+# Enable/disable network access entirely
+# Default: true
+enabled = true
+internet_access = true
+
+[packages]
+# Python packages to install (comma-separated)
+# These will be installed with pip when entering the sandbox
+install = requests,numpy,pandas
+
+[applications]
+# Additional applications to include in sandbox (comma-separated)
+# Must be available on the host system
+include = htop,tree,jq,nano
+
+[ssh]
+# SSH keys to copy into the sandbox (comma-separated)
+# Omit or leave empty to copy all keys found in ~/.ssh or the mounted directory
+keys = id_rsa,id_ed25519
+
+[environment]
+# Environment variables to set in the sandbox
+# These are automatically exported when the sandbox starts
+EDITOR = vim
+PYTHONPATH = /usr/local/lib/python3.*/site-packages
+LANG = en_US.UTF-8
+TZ = UTC
+
+[profile]
+# Custom shell script to execute on sandbox entry
+# This runs after environment variables are set
+script = echo "Custom setup complete"
+       cd /mnt
+       ls -la


### PR DESCRIPTION
## Summary
- add MIT License and README
- support new `[ssh]` config section for copying specific keys
- update sample config with `[ssh]` section
- document new config behaviour

## Testing
- `python3 -m py_compile sandbox`
- `./sandbox --create-sample-config`