### PR TITLE
Enhance binary lookup and OS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Clone this repository and make the `sandbox` script executable:
 chmod +x sandbox
 ```
 
+## Requirements
+
+- Linux is fully supported. macOS can run the script with limited features
+  because `chroot` and namespace tools are restricted.
+- Binaries are located using the `which` command rather than assuming fixed
+  paths.
+
 ## Usage
 
 ```bash

--- a/sandbox
+++ b/sandbox
@@ -59,12 +59,14 @@ import pwd
 import grp
 from pathlib import Path
 import configparser
+import platform
 
 class SandboxManager:
     def __init__(self, config_file=None, mount_dir=None):
         self.config_file = config_file
         self.mount_dir = mount_dir or os.getcwd()
         self.sandbox_root = None
+        self.os_name = platform.system()
         self.config = {}
         self.load_config()
         
@@ -163,22 +165,27 @@ class SandboxManager:
 
     def copy_essential_binaries(self):
         """Copy essential binaries and libraries"""
-        essential_bins = [
-            '/bin/bash', '/bin/sh', '/bin/ls', '/bin/cat', '/bin/grep',
-            '/bin/sed', '/bin/awk', '/bin/cp', '/bin/mv', '/bin/rm',
-            '/bin/mkdir', '/bin/rmdir', '/bin/chmod', '/bin/chown',
-            '/usr/bin/vim', '/usr/bin/nano', '/usr/bin/python3',
-            '/usr/bin/ssh', '/usr/bin/curl', '/usr/bin/wget',
-            '/usr/bin/git', '/bin/tar', '/bin/gzip', '/bin/gunzip',
-            '/usr/bin/ssh-keygen', '/usr/bin/ssh-add', '/usr/bin/ssh-agent'
+        bin_names = [
+            'bash', 'sh', 'ls', 'cat', 'grep', 'sed', 'awk', 'cp', 'mv', 'rm',
+            'mkdir', 'rmdir', 'chmod', 'chown', 'vim', 'nano', 'python3',
+            'ssh', 'curl', 'wget', 'git', 'tar', 'gzip', 'gunzip',
+            'ssh-keygen', 'ssh-add', 'ssh-agent'
         ]
+
+        essential_bins = []
+        for name in bin_names:
+            path = shutil.which(name)
+            if path and path not in essential_bins:
+                essential_bins.append(path)
+            if not path:
+                print(f"Warning: {name} not found, skipping")
         
         # Add configured applications
         for app in self.config['applications']:
             app_path = shutil.which(app)
-            if app_path:
+            if app_path and app_path not in essential_bins:
                 essential_bins.append(app_path)
-            else:
+            elif not app_path:
                 print(f"Warning: Application {app} not found")
         
         for bin_path in essential_bins:
@@ -204,19 +211,29 @@ class SandboxManager:
             
             # Get library dependencies
             try:
-                result = subprocess.run(['ldd', binary_path], 
-                                      capture_output=True, text=True, check=True)
-                
+                if self.os_name == 'Darwin':
+                    cmd = ['otool', '-L', binary_path]
+                else:
+                    cmd = ['ldd', binary_path]
+
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
                 for line in result.stdout.split('\n'):
-                    if '=>' in line:
-                        parts = line.strip().split('=>')
-                        if len(parts) == 2 and parts[1].strip():
-                            lib_path = parts[1].strip().split()[0]
-                            if os.path.exists(lib_path) and lib_path != '(0x':
+                    if self.os_name == 'Darwin':
+                        if line.startswith('\t'):
+                            lib_path = line.strip().split(' ')[0]
+                            if os.path.exists(lib_path):
                                 self.copy_library(lib_path)
-                                
+                    else:
+                        if '=>' in line:
+                            parts = line.strip().split('=>')
+                            if len(parts) == 2 and parts[1].strip():
+                                lib_path = parts[1].strip().split()[0]
+                                if os.path.exists(lib_path) and lib_path != '(0x':
+                                    self.copy_library(lib_path)
+
             except subprocess.CalledProcessError:
-                # Binary might be statically linked or ldd might fail
+                # Binary might be statically linked or tool might fail
                 pass
                 
         except Exception as e:
@@ -534,7 +551,15 @@ For more information, see the help documentation at the top of this script.
     print(f"Config: {args.config or 'default settings'}")
     print(f"Mount: {mount_dir} -> /mnt")
     print()
-    
+
+    os_name = platform.system()
+    print(f"Detected OS: {os_name}")
+    if os_name not in ('Linux', 'Darwin'):
+        print(f"Unsupported operating system: {os_name}")
+        return
+    if os_name != 'Linux':
+        print("Warning: Full isolation features are only available on Linux.")
+
     if os.getuid() != 0:
         print("Warning: This tool works best when run as root for full isolation.")
         print("Running with limited privileges...")


### PR DESCRIPTION
## Summary
- locate required binaries using `which` instead of hard-coded paths
- add OS detection and warn when not running on Linux
- support library dependency lookup via `ldd` on Linux and `otool` on macOS
- document requirements in README

## Testing
- `python3 -m py_compile sandbox`
- `python3 sandbox --create-sample-config`
- `python3 sandbox --config sb.conf.example --mnt /tmp`